### PR TITLE
feat(US-13.2): Implementar validación de saldo y mock de Módulo 1 en transferencias

### DIFF
--- a/docs/feature-us-13.2-validar-saldo.md
+++ b/docs/feature-us-13.2-validar-saldo.md
@@ -1,0 +1,28 @@
+# Documentación Técnica: US-13.2 Validación de Saldo en Transferencias
+
+## Contexto
+Esta funcionalidad introduce validaciones de reglas de negocio previas a la inserción de una transacción en el mempool. El objetivo es garantizar que el emisor disponga de saldo suficiente y que la wallet receptora sea válida dentro del ecosistema UFROCoin, previniendo el doble gasto o la quema accidental de fondos.
+
+## Arquitectura
+
+1. **API Router (`src/api/transaction_router.py`)**: 
+   Expone el endpoint `POST /transactions/`. Implementa el manejo controlado de excepciones, transformando los errores de validación de negocio en respuestas `HTTP 400 Bad Request` con descripciones explícitas (ej. "Saldo insuficiente"). Integra metadatos para la autogeneración de OpenAPI (Swagger).
+
+2. **Capa de Servicios (`src/services/transaction_service.py`)**:
+   Incorpora la validación centralizada mediante el método `calculate_balance(address)`. El saldo real se obtiene iterando el historial inmutable de transacciones confirmadas en la colección `blocks` y descontando preventivamente los fondos ya comprometidos en la colección `transacciones` (mempool) con estado `PENDING`.
+
+3. **Integración Externa (`src/services/external_wallet_service.py`)**:
+   Abstracción de cliente (Mock) que simula el consumo del endpoint de verificación del Módulo 1 (Usuarios y Wallets). Provee el método `check_wallet_exists`, permitiendo independizar el avance de desarrollo entre equipos.
+
+## Guía de Pruebas (Swagger UI)
+
+**Requisito previo:** Asegurarse de que la infraestructura base (MongoDB y RabbitMQ) esté corriendo localmente mediante `docker-compose up --build -d`.
+
+1. Levantar la API y acceder a la interfaz interactiva en `http://localhost:8000/docs`.
+2. Desplegar el endpoint `POST /transactions/` y hacer clic en "Try it out".
+3. **Validación de Wallet Inexistente:** - Enviar el payload con un destinatario (`to`) que comience con la palabra "invalid". 
+   - *Resultado esperado:* Código `400 Bad Request` indicando que la wallet de destino es inválida.
+4. **Validación de Saldo Insuficiente:** - Ejecutar una transferencia con un monto (`amount`) superior al saldo histórico disponible de la wallet `from`. 
+   - *Resultado esperado:* Código `400 Bad Request` detallando "Saldo insuficiente. Saldo disponible: X.X".
+5. **Ejecución Exitosa:** - Proveer una wallet emisora con fondos confirmados (sin deudas en mempool) y una receptora válida. 
+   - *Resultado esperado:* Código `201 Created` retornando el nuevo objeto transacción en estado `PENDING`.

--- a/src/api/transaction_router.py
+++ b/src/api/transaction_router.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException, Depends, status
 from src.models.transaction import Transaction
 from src.services.transaction_service import TransactionService
 from src.core.database import get_mongo_client
@@ -17,7 +17,17 @@ def get_transaction_service():
 
 # --- Endpoints ---
 
-@router.post("/", response_model=Transaction)
+@router.post(
+    "/", 
+    response_model=Transaction,
+    status_code=status.HTTP_201_CREATED,
+    summary="Crear una nueva transferencia",
+    description="Registra una transferencia en el mempool tras validar que la wallet de destino existe y que el emisor tiene saldo suficiente.",
+    responses={
+        400: {"description": "Error de validación: Saldo insuficiente o wallet de destino no encontrada"},
+        500: {"description": "Error interno del servidor"}
+    }
+)
 async def create_transaction(
     transaction: Transaction, 
     service: TransactionService = Depends(get_transaction_service)
@@ -25,7 +35,16 @@ async def create_transaction(
     try:
         new_tx = service.create_transfer(transaction.model_dump(by_alias=True))
         return new_tx
+    except ValueError as ve:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, 
+            detail=str(ve)
+        )
     except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception:
-        raise HTTPException(status_code=500, detail="Error interno del servidor")
+        # Vamos a imprimir el error en consola y enviarlo en la respuesta
+        import traceback
+        traceback.print_exc() 
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, 
+            detail=f"DETALLE DEL ERROR: {str(e)}"
+        )

--- a/src/api/transaction_router.py
+++ b/src/api/transaction_router.py
@@ -27,3 +27,5 @@ async def create_transaction(
         return new_tx
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except Exception:
+        raise HTTPException(status_code=500, detail="Error interno del servidor")

--- a/src/services/external_wallet_service.py
+++ b/src/services/external_wallet_service.py
@@ -1,0 +1,17 @@
+import logging
+
+# --- Inicializacion ---
+
+logger = logging.getLogger(__name__)
+
+# --- Lógica de Servicio Externo ---
+
+class ExternalWalletService:
+    def __init__(self, base_url:str = "http://modulo1-usuario:8000/api"):
+        self.base_url = base_url
+
+    def check_wallet_exist(self, address: str) -> bool:
+        if not address or address.startwith("invalid"):
+            return False
+        
+        return True

--- a/src/services/external_wallet_service.py
+++ b/src/services/external_wallet_service.py
@@ -11,7 +11,7 @@ class ExternalWalletService:
         self.base_url = base_url
 
     def check_wallet_exist(self, address: str) -> bool:
-        if not address or address.startwith("invalid"):
+        if not address or address.startswith("invalid"):
             return False
         
         return True

--- a/src/services/transaction_service.py
+++ b/src/services/transaction_service.py
@@ -11,14 +11,14 @@ class TransactionService:
     def __init__(self, db_client):
         self.db = db_client.blockchain_db
         self.publisher = RabbitMQPublisher()
-        self.wallet_service = ExternalWalletService
+        self.wallet_service = ExternalWalletService()
     
     # --- Validaciones ---
 
     def calculate_balance(self, address: str) -> float:
         balance = 0.0
 
-        block = self.db.blocks.find()
+        blocks = self.db.blocks.find()
         for block in blocks:
             for tx in block.get("transactions", []):
                 if tx.get("to") == address:

--- a/src/services/transaction_service.py
+++ b/src/services/transaction_service.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from src.core.constants import TRANSACTION_EVENT_ROUTING_KEY
 from src.models.transaction import Transaction
 from src.core.rabbitmq_publisher import RabbitMQPublisher
+from src.services.external_wallet_service import ExternalWalletService
 
 # --- Lógica de Negocio ---
 
@@ -10,10 +11,39 @@ class TransactionService:
     def __init__(self, db_client):
         self.db = db_client.blockchain_db
         self.publisher = RabbitMQPublisher()
+        self.wallet_service = ExternalWalletService
+    
+    # --- Validaciones ---
+
+    def calculate_balance(self, address: str) -> float:
+        balance = 0.0
+
+        block = self.db.blocks.find()
+        for block in blocks:
+            for tx in block.get("transactions", []):
+                if tx.get("to") == address:
+                    balance += tx.get("amount", 0.0)
+                if tx.get("from") == address:
+                    balance -= tx.get("amount", 0.0)
+
+        pending_txs = self.dpending_txs = self.db.transacciones.find({"from": address, "status": "PENDING"})
+        for tx in pending_txs:
+            balance -= tx.get("amount", 0.0)
+
+        return balance
 
     # --- Gestión de Transferencias ---
 
     def create_transfer(self, transaction_data: dict) -> dict:
+        if not self.wallet_service.check_wallet_exist(transaction_data.get("to")):
+            raise ValueError("La wallet de destino es invalida o no existe")
+        
+        if transaction_data.get("type") == "TRANSFER":
+            current_balance = self.calculate_balance(transaction_data.get("from"))
+            if current_balance < transaction_data.get("amount"):
+                raise ValueError(f"Saldo insuficiente. Saldo disponible: {current_balance}")
+
+
         new_transaction = Transaction(**transaction_data)
         transaction_dict = new_transaction.model_dump(by_alias=True)
         


### PR DESCRIPTION
## **Contexto / Ticket:**
Resolución de la **US-13.2**. Este PR introduce las validaciones de negocio necesarias antes de insertar una transacción en el mempool. El objetivo es garantizar la integridad del ecosistema previniendo el doble gasto o el envío de fondos a billeteras inexistentes.

## **Cambios Principales:**
* **Capa de Servicios (`transaction_service.py`):**
    * Se implementó el método `calculate_balance(address)`. Calcula el saldo real leyendo el historial inmutable (`blocks`) y descuenta de forma preventiva los fondos comprometidos en la colección de transacciones (`status: PENDING`).
    * Se agregó la validación de fondos suficientes previa a la inserción en base de datos y publicación en RabbitMQ.
* **Mock de Integración Externa (`external_wallet_service.py`):**
    * Se creó un servicio simulado para validar la existencia de la wallet receptora, desacoplando nuestro desarrollo del Módulo 1 (Usuarios).
* **API Router (`transaction_router.py`):**
    * Se implementó el manejo de errores de negocio para capturar `ValueError` y retornar códigos `HTTP 400 Bad Request` limpios ("Saldo insuficiente" o "Wallet inválida").
    * Se agregó la documentación de esquemas y respuestas (201, 400, 500) para **Swagger/OpenAPI**.
* **Bugfixes:**
    * Se corrigieron referencias de instancia (`self.wallet_service`), definición de variables de persistencia en cálculo de saldo y errores tipográficos (`startswith`) detectados durante las pruebas locales.
* **Documentación:**
    * Se agregó el manual técnico `docs/feature-us-13.2-validar-saldo.md` con la arquitectura y guía de pruebas cumpliendo con el Definition of Done (DoD).

## **Cómo Probar (Pasos para el Reviewer):**
1.  Asegurarse de tener la infraestructura levantada: `docker-compose up --build -d`
2.  Navegar a la interfaz de Swagger: `http://localhost:8000/docs`
3.  Desplegar el endpoint `POST /transactions/`.
4.  **Probar Wallet Inválida:** Enviar un payload donde el campo `to` inicie con `"invalid"`. Debe retornar `400 Bad Request`.
5.  **Probar Saldo Insuficiente:** Enviar una transacción por un monto mayor a los ingresos históricos del emisor. Debe retornar `400 Bad Request` indicando el saldo real.
6.  **Probar Éxito:** Realizar un envío válido y verificar que retorne `201 Created` y la inserte en estado `PENDING`.

## **Checklist de Calidad:**
- [x] El código sigue los estándares del proyecto.
- [x] La documentación de Swagger fue actualizada y validada.
- [x] Se resolvieron todos los errores de sintaxis y dependencias locales.
- [x] Se incluye archivo de documentación técnica en la carpeta `/docs`.