### PR TITLE
feat(transactions): expose pending transaction mempool endpoint

### DIFF
--- a/docs/database-configuration-refactor-plan.md
+++ b/docs/database-configuration-refactor-plan.md
@@ -1,0 +1,366 @@
+# Plan de Refactor: Configuracion Centralizada de Base de Datos y Colecciones
+
+## Objetivo
+
+Centralizar la configuracion de la base de datos MongoDB y los nombres de colecciones en un unico punto del proyecto, usando variables de entorno con valores por defecto seguros.
+
+Configuracion propuesta por defecto:
+
+- Base de datos: `ufrocoin`
+- Coleccion de bloques: `blocks`
+- Coleccion de transacciones: `transactions`
+- Coleccion de metadata de cadena: `chain_metadata`
+
+## Problema Actual
+
+Actualmente el proyecto usa mas de una convencion para acceder a MongoDB.
+
+Por un lado, `src/core/database.py` define:
+
+```python
+DEFAULT_DATABASE_NAME = "ufrocoin"
+
+def get_transactions_collection() -> Any:
+    return get_database()["transactions"]
+```
+
+Esto apunta a:
+
+```text
+ufrocoin.transactions
+```
+
+o a la base configurada por `MONGO_DB_NAME` / `MONGODB_DB_NAME`.
+
+Pero otros servicios usan nombres hardcodeados:
+
+```python
+self.db = db_client.blockchain_db
+self.db.transacciones
+```
+
+y:
+
+```python
+db = client.get_database("blockchain_db")
+db.transacciones
+```
+
+Esto apunta a:
+
+```text
+blockchain_db.transacciones
+```
+
+## Por Que Se Deberia Implementar
+
+Esta inconsistencia puede provocar que distintos endpoints lean o escriban en bases/colecciones diferentes.
+
+Ejemplo de riesgo:
+
+1. `POST /api/transactions/` guarda una transaccion en `blockchain_db.transacciones`.
+2. `GET /api/transaction/pending` podria leer desde otra coleccion si se usa `get_transactions_collection()`.
+3. `GET /history/{address}` podria consultar otra fuente.
+4. El calculo de saldo podria descontar pendientes desde una coleccion distinta.
+5. El sistema pareceria funcionar parcialmente, pero los datos quedarian desincronizados.
+
+Centralizar esta configuracion reduce ese riesgo y permite que todos los modulos compartan una sola fuente de verdad.
+
+## Beneficios
+
+- Evita nombres de BD hardcodeados en servicios.
+- Permite cambiar la base de datos desde `.env`.
+- Permite cambiar nombres de colecciones desde `.env`.
+- Hace que creacion de transacciones, historial, saldo y mempool usen la misma coleccion.
+- Facilita despliegue en distintos entornos: local, testing, staging, produccion.
+- Reduce deuda tecnica antes de que existan datos reales.
+- Evita migraciones futuras innecesarias.
+- Facilita pruebas automatizadas usando bases temporales.
+- Mantiene el codigo de negocio desacoplado de detalles de infraestructura.
+
+## Variables de Entorno Propuestas
+
+Agregar al `.env.example`:
+
+```env
+MONGO_DB_NAME=ufrocoin
+MONGO_BLOCKS_COLLECTION=blocks
+MONGO_TRANSACTIONS_COLLECTION=transactions
+MONGO_CHAIN_METADATA_COLLECTION=chain_metadata
+```
+
+Mantener compatibilidad con `MONGODB_DB_NAME`, que ya existe en el proyecto.
+
+## Convencion Recomendada
+
+Como el proyecto aun no ha sido desplegado y no hay datos productivos, se recomienda usar nombres consistentes en ingles:
+
+```text
+ufrocoin.blocks
+ufrocoin.transactions
+ufrocoin.chain_metadata
+```
+
+Esto se alinea con los nombres ya definidos parcialmente en `src/core/database.py`.
+
+## Cambios Propuestos
+
+### 1. Centralizar nombres en `src/core/database.py`
+
+Agregar constantes por defecto:
+
+```python
+DEFAULT_DATABASE_NAME = "ufrocoin"
+DEFAULT_BLOCKS_COLLECTION_NAME = "blocks"
+DEFAULT_TRANSACTIONS_COLLECTION_NAME = "transactions"
+DEFAULT_CHAIN_METADATA_COLLECTION_NAME = "chain_metadata"
+```
+
+Agregar helpers:
+
+```python
+def get_blocks_collection_name() -> str:
+    return os.getenv("MONGO_BLOCKS_COLLECTION", DEFAULT_BLOCKS_COLLECTION_NAME)
+
+
+def get_transactions_collection_name() -> str:
+    return os.getenv("MONGO_TRANSACTIONS_COLLECTION", DEFAULT_TRANSACTIONS_COLLECTION_NAME)
+
+
+def get_chain_metadata_collection_name() -> str:
+    return os.getenv("MONGO_CHAIN_METADATA_COLLECTION", DEFAULT_CHAIN_METADATA_COLLECTION_NAME)
+```
+
+Actualizar helpers existentes:
+
+```python
+def get_blocks_collection() -> Any:
+    return get_database()[get_blocks_collection_name()]
+
+
+def get_transactions_collection() -> Any:
+    return get_database()[get_transactions_collection_name()]
+
+
+def get_chain_metadata_collection() -> Any:
+    return get_database()[get_chain_metadata_collection_name()]
+```
+
+### 2. Actualizar `TransactionService`
+
+Reemplazar accesos directos:
+
+```python
+self.db = db_client.blockchain_db
+self.db.blocks
+self.db.transacciones
+```
+
+por colecciones centralizadas:
+
+```python
+from src.core.database import get_blocks_collection, get_transactions_collection
+```
+
+y usar:
+
+```python
+self.blocks_collection = get_blocks_collection()
+self.transactions_collection = get_transactions_collection()
+```
+
+Luego reemplazar:
+
+```python
+self.db.blocks.find()
+self.db.transacciones.find(...)
+self.db.transacciones.insert_one(...)
+```
+
+por:
+
+```python
+self.blocks_collection.find()
+self.transactions_collection.find(...)
+self.transactions_collection.insert_one(...)
+```
+
+### 3. Actualizar `history_service.py`
+
+Reemplazar:
+
+```python
+client = get_db_client()
+db = client.get_database("blockchain_db")
+pending_cursor = db.transacciones.find(query)
+blocks_cursor = db.blocks.find(...)
+```
+
+por:
+
+```python
+from src.core.database import get_blocks_collection, get_transactions_collection
+
+transactions_collection = get_transactions_collection()
+blocks_collection = get_blocks_collection()
+```
+
+y usar:
+
+```python
+pending_cursor = transactions_collection.find(query)
+blocks_cursor = blocks_collection.find(...)
+```
+
+### 4. Revisar referencias hardcodeadas
+
+Buscar referencias a:
+
+```text
+blockchain_db
+transacciones
+get_database("blockchain_db")
+```
+
+La meta es que los servicios no dependan directamente del nombre fisico de la base ni de las colecciones.
+
+### 5. Actualizar `.env.example`
+
+Agregar las nuevas variables:
+
+```env
+MONGO_DB_NAME=ufrocoin
+MONGO_BLOCKS_COLLECTION=blocks
+MONGO_TRANSACTIONS_COLLECTION=transactions
+MONGO_CHAIN_METADATA_COLLECTION=chain_metadata
+```
+
+No modificar `.env` real sin acuerdo del grupo, ya que puede contener configuracion local o sensible.
+
+## Impacto Esperado en US-15
+
+El endpoint:
+
+```http
+GET /api/transaction/pending
+```
+
+seguira funcionando igual para el consumidor.
+
+La diferencia es interna:
+
+Antes podria depender de:
+
+```text
+blockchain_db.transacciones
+```
+
+Despues usara por defecto:
+
+```text
+ufrocoin.transactions
+```
+
+Si el grupo decide volver a la convencion anterior, no sera necesario tocar codigo. Bastara configurar:
+
+```env
+MONGO_DB_NAME=blockchain_db
+MONGO_TRANSACTIONS_COLLECTION=transacciones
+```
+
+## Impacto en Otros Flujos
+
+### Creacion de transacciones
+
+`POST /api/transactions/` guardara en la coleccion centralizada.
+
+### Historial
+
+`GET /history/{address}` consultara la misma coleccion que usa la creacion de transacciones.
+
+### Saldo
+
+El calculo de saldo descontara pendientes desde la misma coleccion donde se crean las transacciones.
+
+### Blockchain
+
+Los bloques se consultaran desde la coleccion centralizada `blocks`.
+
+## Riesgos
+
+- Si alguien del equipo ya esta usando manualmente `blockchain_db.transacciones`, dejara de ver datos por defecto.
+- Si existen scripts externos que esperan `transacciones`, deberan actualizarse o configurar el `.env`.
+- Si se cambia solo una parte del codigo, puede aumentar la inconsistencia en vez de resolverla.
+- Si se modifica `.env` local sin coordinar, algunos desarrolladores podrian apuntar a bases distintas.
+
+## Mitigaciones
+
+- Implementar el cambio de forma completa en una sola rama.
+- No renombrar datos existentes porque el proyecto aun no esta desplegado.
+- Mantener variables de entorno para poder volver a nombres anteriores sin tocar codigo.
+- Documentar la convencion acordada en este archivo.
+- Verificar todos los endpoints afectados despues del cambio.
+
+## Verificaciones Tecnicas
+
+Ejecutar:
+
+```powershell
+python -c "from src.main import app; print('ok')"
+python -m compileall src
+python -c "from src.main import app; print([(sorted(route.methods), route.path) for route in app.routes if 'transaction' in route.path])"
+```
+
+Resultado esperado:
+
+```text
+ok
+POST /api/transactions/
+GET /api/transaction/pending
+```
+
+Buscar referencias restantes:
+
+```text
+blockchain_db
+transacciones
+get_database("blockchain_db")
+```
+
+Resultado esperado:
+
+- No deberian quedar referencias hardcodeadas en servicios.
+- Podrian quedar referencias solo en documentacion historica.
+
+## Verificacion Funcional Recomendada
+
+1. Levantar MongoDB y API.
+2. Crear una transaccion con `POST /api/transactions/`.
+3. Confirmar que se guarda en `ufrocoin.transactions`.
+4. Consultar `GET /api/transaction/pending`.
+5. Confirmar que la transaccion aparece en `data`.
+6. Consultar historial con `GET /history/{address}`.
+7. Confirmar que historial lee desde la misma fuente.
+8. Cambiar manualmente el estado de una transaccion a `CONFIRMED`.
+9. Confirmar que deja de aparecer en `/api/transaction/pending`.
+
+## Decision Solicitada al Grupo
+
+Se propone aprobar la siguiente convencion por defecto:
+
+```text
+MONGO_DB_NAME=ufrocoin
+MONGO_BLOCKS_COLLECTION=blocks
+MONGO_TRANSACTIONS_COLLECTION=transactions
+MONGO_CHAIN_METADATA_COLLECTION=chain_metadata
+```
+
+Y exigir que todo servicio acceda a MongoDB mediante helpers centralizados en:
+
+```text
+src/core/database.py
+```
+
+## Recomendacion
+
+Implementar este refactor ahora, antes del despliegue y antes de acumular datos reales. El costo actual es bajo y evita problemas de sincronizacion entre endpoints en futuras historias de usuario.

--- a/docs/feature-us-15-pending-transactions-plan.md
+++ b/docs/feature-us-15-pending-transactions-plan.md
@@ -1,0 +1,98 @@
+# US-15: Transacciones pendientes visibles
+
+## Objetivo
+
+Implementar el endpoint publico `GET /api/transaction/pending` para consultar las transacciones del mempool que aun tienen estado `PENDING`.
+
+## Contexto revisado antes de crear codigo
+
+- El proyecto usa FastAPI en `src/main.py`.
+- El router de transacciones actual se registra con prefijo global `/api`.
+- El endpoint existente de creacion de transacciones es `POST /api/transactions/`.
+- Las transacciones se persisten en MongoDB en `blockchain_db.transacciones`.
+- El modelo `Transaction` ya guarda `status` con valor por defecto `PENDING`.
+- La confirmacion automatica `PENDING -> CONFIRMED` corresponde al flujo de mineria y queda fuera del alcance directo de US-15.
+
+## Pasos antes de implementar codigo
+
+1. Revisar `src/api/transaction_router.py` para no romper `POST /api/transactions/`.
+2. Revisar `src/services/transaction_service.py` para reutilizar la conexion y coleccion existentes.
+3. Revisar `src/models/transaction.py` para definir una respuesta tipada del endpoint.
+4. Confirmar que el endpoint solicitado debe ser exactamente `GET /api/transaction/pending`.
+5. Confirmar que el endpoint es publico y no debe usar JWT ni validacion de propiedad de wallet.
+6. Confirmar que la respuesta debe usar wrapper segun la documentacion:
+
+```json
+{
+  "status": "ok",
+  "data": []
+}
+```
+
+## Cambios de codigo previstos
+
+1. Agregar modelos de respuesta en `src/models/transaction.py`:
+   - `PendingTransactionData`
+   - `PendingTransactionsResponse`
+2. Agregar `TransactionService.get_pending_transactions()` para consultar solo documentos con `status: "PENDING"`.
+3. Mapear cada documento Mongo a los campos publicos requeridos:
+   - `id`
+   - `from`
+   - `to`
+   - `amount`
+   - `timestamp`
+4. Agregar un router adicional con prefijo `/transaction` para no modificar el endpoint existente `/transactions`.
+5. Registrar el nuevo router en `src/main.py` con prefijo global `/api`.
+
+## Pasos despues de implementar codigo
+
+1. Verificar que la app FastAPI importe correctamente.
+2. Verificar que exista la ruta `GET /api/transaction/pending`.
+3. Verificar que siga existiendo `POST /api/transactions/`.
+4. Verificar que el endpoint publico no tenga dependencias de autenticacion.
+5. Verificar que la respuesta tenga wrapper `status: "ok"` y `data` como lista.
+6. Verificar que cada entrada en `data` incluya solo `id`, `from`, `to`, `amount` y `timestamp`.
+7. Verificar que una transaccion con `status: "CONFIRMED"` no aparezca en el resultado.
+
+## Resultado esperado
+
+Solicitud:
+
+```http
+GET /api/transaction/pending
+```
+
+Respuesta exitosa:
+
+```json
+{
+  "status": "ok",
+  "data": [
+    {
+      "id": "665f1c2e8f5a8f2a9c4d0001",
+      "from": "wallet_origen",
+      "to": "wallet_destino",
+      "amount": 10.0,
+      "timestamp": "2026-05-13T12:00:00Z"
+    }
+  ]
+}
+```
+
+## Criterios de aceptacion cubiertos
+
+- `GET /api/transaction/pending` retorna todas las transacciones en estado `PENDING`.
+- Cada entrada del mempool incluye `id`, `from`, `to`, `amount`, `timestamp`.
+- El endpoint es publico.
+- Una transaccion deja de aparecer cuando su estado cambia a `CONFIRMED` por el flujo de mineria.
+
+## Dependencia con US-16
+
+US-15 solo consulta el mempool. La actualizacion del estado a `CONFIRMED` al incluir una transaccion en un bloque minado debe implementarse en US-16 o en el modulo de mineria correspondiente.
+
+## Comandos de verificacion
+
+```powershell
+python -c "from src.main import app; print('ok')"
+python -c "from src.main import app; print([route.path for route in app.routes if 'transaction' in route.path])"
+```

--- a/src/api/transaction_router.py
+++ b/src/api/transaction_router.py
@@ -60,7 +60,7 @@ async def create_transaction(
     response_model=PendingTransactionsResponse,
     response_model_by_alias=True,  # ← agregar esto
     summary="Listar transacciones pendientes del mempool",
-    ...
+    description="Retorna publicamente todas las transacciones con estado PENDING que aun no han sido confirmadas en un bloque.",
 )
 async def get_pending_transactions(
     service: TransactionService = Depends(get_transaction_service),

--- a/src/api/transaction_router.py
+++ b/src/api/transaction_router.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException, Depends, status
-from src.models.transaction import Transaction
+from src.models.transaction import PendingTransactionsResponse, Transaction
 from src.services.transaction_service import TransactionService
 from src.core.database import get_mongo_client
 
@@ -7,6 +7,11 @@ from src.core.database import get_mongo_client
 
 router = APIRouter(
     prefix="/transactions",
+    tags=["transactions"]
+)
+
+pending_router = APIRouter(
+    prefix="/transaction",
     tags=["transactions"]
 )
 
@@ -48,3 +53,18 @@ async def create_transaction(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, 
             detail=f"DETALLE DEL ERROR: {str(e)}"
         )
+
+
+@pending_router.get(
+    "/pending",
+    response_model=PendingTransactionsResponse,
+    summary="Listar transacciones pendientes del mempool",
+    description="Retorna publicamente todas las transacciones con estado PENDING que aun no han sido confirmadas en un bloque.",
+)
+async def get_pending_transactions(
+    service: TransactionService = Depends(get_transaction_service),
+):
+    return {
+        "status": "ok",
+        "data": service.get_pending_transactions(),
+    }

--- a/src/api/transaction_router.py
+++ b/src/api/transaction_router.py
@@ -58,8 +58,9 @@ async def create_transaction(
 @pending_router.get(
     "/pending",
     response_model=PendingTransactionsResponse,
+    response_model_by_alias=True,  # ← agregar esto
     summary="Listar transacciones pendientes del mempool",
-    description="Retorna publicamente todas las transacciones con estado PENDING que aun no han sido confirmadas en un bloque.",
+    ...
 )
 async def get_pending_transactions(
     service: TransactionService = Depends(get_transaction_service),

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from src.api.block_router import router as block_router
 from src.api.global_router import router as global_router
-from src.api.transaction_router import router as transaction_router
+from src.api.transaction_router import pending_router, router as transaction_router
 from src.api.history_router import router as history_router
 from src.api.startup import lifespan
 
@@ -15,4 +15,5 @@ app = FastAPI(
 app.include_router(global_router)
 app.include_router(block_router, prefix="/api")
 app.include_router(transaction_router, prefix="/api")
+app.include_router(pending_router, prefix="/api")
 app.include_router(history_router)

--- a/src/models/transaction.py
+++ b/src/models/transaction.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field, ConfigDict
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Literal, Optional
 from enum import Enum
 
 # --- Enumeraciones ---
@@ -26,3 +26,18 @@ class Transaction(BaseModel):
     block_index: Optional[int] = None
 
     model_config = ConfigDict(populate_by_name=True)
+
+
+class PendingTransactionData(BaseModel):
+    id: str
+    sender: str = Field(..., alias="from")
+    receiver: str = Field(..., alias="to")
+    amount: float
+    timestamp: str
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class PendingTransactionsResponse(BaseModel):
+    status: Literal["ok"]
+    data: list[PendingTransactionData]

--- a/src/services/transaction_service.py
+++ b/src/services/transaction_service.py
@@ -68,6 +68,20 @@ class TransactionService:
         )
 
         return transaction_dict
+
+    def get_pending_transactions(self) -> list[dict]:
+        pending_txs = self.db.transacciones.find({"status": "PENDING"})
+
+        return [
+            {
+                "id": str(tx.get("_id", "")),
+                "from": tx.get("from"),
+                "to": tx.get("to"),
+                "amount": tx.get("amount"),
+                "timestamp": tx.get("timestamp"),
+            }
+            for tx in pending_txs
+        ]
     
     #--- Historial de Transacciones ---
 


### PR DESCRIPTION
Implementa la visualización de transacciones pendientes del mempool mediante el nuevo endpoint público:
GET /api/transaction/pending
El endpoint retorna todas las transacciones con estado PENDING, permitiendo consultar qué operaciones aún no han sido confirmadas en un bloque.
Cambios principales
- Se agrega el router pending_router para exponer GET /api/transaction/pending.
- Se registra el nuevo endpoint en src/main.py bajo el prefijo global /api.
- Se incorpora TransactionService.get_pending_transactions() para consultar transacciones pendientes desde MongoDB.
- Se agregan modelos de respuesta tipados:
  - PendingTransactionData
  - PendingTransactionsResponse
- La respuesta mantiene el formato esperado:
{
  "status": "ok",
  "data": []
}
Campos retornados
Cada transacción pendiente incluye:
- id
- from
- to
- amount
- timestamp
Documentación incluida
- Se agrega el plan de implementación de US-15 para transacciones pendientes.
- Se agrega una propuesta de refactor para centralizar la configuración de base de datos y colecciones MongoDB.
Criterios cubiertos
- Permite consultar públicamente las transacciones en estado PENDING.
- No requiere autenticación.
- Mantiene funcionando el endpoint existente POST /api/transactions/.
- Prepara la base para que futuras historias, como minería o confirmación de transacciones, puedan actualizar el estado a CONFIRMED.