### PR TITLE
test(core): add unit tests for blockchain services and hash utilities

### DIFF
--- a/test/test_block_service.py
+++ b/test/test_block_service.py
@@ -1,0 +1,479 @@
+"""
+Tests unitarios para src.services.block_service.BlockService.
+
+Estrategia:
+- Se mockea get_blocks_collection para evitar dependencia de MongoDB.
+- Se verifica que BlockService llame correctamente a la colección con los
+  parámetros correctos (queries, skip, limit, sort).
+- Se verifica el comportamiento de _with_confirmed_transaction_indexes.
+"""
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from src.models.block import Block
+
+
+# ---------------------------------------------------------------------------
+# Fixture: bloque de ejemplo y helper para mock de colección
+# ---------------------------------------------------------------------------
+
+SAMPLE_BLOCK_DOC = {
+    "index": 1,
+    "timestamp": "2026-04-10T10:00:00Z",
+    "transactions": [
+        {
+            "id": "tx-001",
+            "from": "addr_a",
+            "to": "addr_b",
+            "amount": 25.0,
+            "type": "TRANSFER",
+            "timestamp": "2026-04-10T09:59:00Z",
+        }
+    ],
+    "previous_hash": "a" * 64,
+    "nonce": 48271,
+    "hash": "b" * 64,
+}
+
+
+def make_mock_collection(find_return=None, find_one_return=None, count_return=0):
+    """Construye un mock de colección MongoDB con valores por defecto."""
+    col = MagicMock()
+    col.count_documents.return_value = count_return
+
+    # Mockear la cadena: find().sort().skip().limit() => iterable
+    cursor = MagicMock()
+    cursor.__iter__ = MagicMock(return_value=iter(find_return or []))
+    col.find.return_value.sort.return_value.skip.return_value.limit.return_value = cursor
+
+    col.find_one.return_value = find_one_return
+    return col
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_last_block
+# ---------------------------------------------------------------------------
+
+
+class TestGetLastBlock:
+    """BlockService.get_last_block — obtiene el bloque con mayor índice."""
+
+    def test_returns_last_block_when_exists(self):
+        """Debe retornar el documento del bloque más reciente."""
+        with patch("src.services.block_service.get_blocks_collection") as mock_col_fn:
+            mock_col_fn.return_value.find_one.return_value = SAMPLE_BLOCK_DOC
+            from src.services.block_service import BlockService
+            service = BlockService()
+
+            result = service.get_last_block()
+
+            assert result == SAMPLE_BLOCK_DOC
+
+    def test_returns_none_when_collection_is_empty(self):
+        """Debe retornar None si no hay bloques en la colección."""
+        with patch("src.services.block_service.get_blocks_collection") as mock_col_fn:
+            mock_col_fn.return_value.find_one.return_value = None
+            from src.services.block_service import BlockService
+            service = BlockService()
+
+            result = service.get_last_block()
+
+            assert result is None
+
+    def test_calls_find_one_with_descending_sort(self):
+        """La query a MongoDB debe ordenar por index DESCENDING."""
+        with patch("src.services.block_service.get_blocks_collection") as mock_col_fn:
+            mock_col_fn.return_value.find_one.return_value = None
+            from src.services.block_service import BlockService
+            service = BlockService()
+
+            service.get_last_block()
+
+            call_kwargs = mock_col_fn.return_value.find_one.call_args
+            # Verificar que se pasa el parámetro sort
+            assert call_kwargs is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests: save_block
+# ---------------------------------------------------------------------------
+
+
+class TestSaveBlock:
+    """BlockService.save_block — persiste un bloque en MongoDB."""
+
+    def test_save_block_dict_calls_insert_one(self):
+        """Con un dict, debe llamar insert_one y retornar el mismo dict."""
+        with patch("src.services.block_service.get_blocks_collection") as mock_col_fn:
+            from src.services.block_service import BlockService
+            service = BlockService()
+
+            block_dict = {"index": 2, "hash": "c" * 64}
+            result = service.save_block(block_dict)
+
+            mock_col_fn.return_value.insert_one.assert_called_once_with(block_dict)
+            assert result == block_dict
+
+    def test_save_block_model_calls_insert_one(self):
+        """Con un objeto Block, debe hacer model_dump y llamar insert_one."""
+        with patch("src.services.block_service.get_blocks_collection") as mock_col_fn:
+            from src.services.block_service import BlockService
+            service = BlockService()
+
+            block = Block(
+                index=2,
+                timestamp="2026-04-10T10:00:00Z",
+                transactions=[],
+                previous_hash="a" * 64,
+                nonce=0,
+                hash="c" * 64,
+            )
+            result = service.save_block(block)
+
+            assert mock_col_fn.return_value.insert_one.called
+            assert result["index"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: create_genesis_block
+# ---------------------------------------------------------------------------
+
+
+class TestCreateGenesisBlock:
+    """BlockService.create_genesis_block — delega en save_block."""
+
+    def test_delegates_to_save_block(self):
+        """create_genesis_block debe llamar a save_block con el bloque dado."""
+        with patch("src.services.block_service.get_blocks_collection") as mock_col_fn:
+            from src.services.block_service import BlockService
+            service = BlockService()
+
+            block = Block(
+                index=0,
+                timestamp="2026-04-09T12:00:00Z",
+                transactions=[],
+                previous_hash="0" * 64,
+                nonce=0,
+                hash="genesis_hash" + "0" * 52,
+            )
+            service.create_genesis_block(block)
+
+            assert mock_col_fn.return_value.insert_one.called
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_chain
+# ---------------------------------------------------------------------------
+
+
+class TestGetChain:
+    """BlockService.get_chain — paginación y orden ascendente."""
+
+    def test_calls_count_documents(self):
+        """Debe llamar count_documents para calcular el total."""
+        with patch("src.services.block_service.get_blocks_collection") as mock_col_fn:
+            col = make_mock_collection(find_return=[SAMPLE_BLOCK_DOC], count_return=5)
+            mock_col_fn.return_value = col
+            from src.services.block_service import BlockService
+            service = BlockService()
+
+            _, total = service.get_chain(page=1, limit=10)
+
+            col.count_documents.assert_called_once_with({})
+            assert total == 5
+
+    def test_default_pagination_skip_is_zero(self):
+        """Con page=1, skip debe ser 0."""
+        with patch("src.services.block_service.get_blocks_collection") as mock_col_fn:
+            col = make_mock_collection(find_return=[], count_return=0)
+            mock_col_fn.return_value = col
+            from src.services.block_service import BlockService
+            service = BlockService()
+
+            service.get_chain(page=1, limit=10)
+
+            # skip = (1-1)*10 = 0
+            col.find.return_value.sort.return_value.skip.assert_called_with(0)
+
+    def test_page_2_skip_is_correct(self):
+        """Con page=2, limit=5, skip debe ser 5."""
+        with patch("src.services.block_service.get_blocks_collection") as mock_col_fn:
+            col = make_mock_collection(find_return=[], count_return=10)
+            mock_col_fn.return_value = col
+            from src.services.block_service import BlockService
+            service = BlockService()
+
+            service.get_chain(page=2, limit=5)
+
+            col.find.return_value.sort.return_value.skip.assert_called_with(5)
+
+    def test_returns_blocks_with_confirmed_indexes(self):
+        """Las transacciones retornadas deben tener block_index inyectado."""
+        with patch("src.services.block_service.get_blocks_collection") as mock_col_fn:
+            col = make_mock_collection(find_return=[SAMPLE_BLOCK_DOC], count_return=1)
+            mock_col_fn.return_value = col
+            from src.services.block_service import BlockService
+            service = BlockService()
+
+            blocks, _ = service.get_chain(page=1, limit=10)
+
+            assert len(blocks) == 1
+            tx = blocks[0]["transactions"][0]
+            assert tx["block_index"] == SAMPLE_BLOCK_DOC["index"]
+            assert tx["status"] == "CONFIRMED"
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_block_by_index y get_block_by_hash
+# ---------------------------------------------------------------------------
+
+
+class TestGetBlockByIndex:
+    """BlockService.get_block_by_index."""
+
+    def test_returns_block_when_found(self):
+        """Debe retornar el bloque cuando MongoDB lo encuentra."""
+        with patch("src.services.block_service.get_blocks_collection") as mock_col_fn:
+            mock_col_fn.return_value.find_one.return_value = SAMPLE_BLOCK_DOC
+            from src.services.block_service import BlockService
+            service = BlockService()
+
+            result = service.get_block_by_index(1)
+
+            assert result is not None
+            assert result["index"] == 1
+
+    def test_returns_none_when_not_found(self):
+        """Debe retornar None si el bloque no existe."""
+        with patch("src.services.block_service.get_blocks_collection") as mock_col_fn:
+            mock_col_fn.return_value.find_one.return_value = None
+            from src.services.block_service import BlockService
+            service = BlockService()
+
+            result = service.get_block_by_index(999)
+
+            assert result is None
+
+
+class TestGetBlockByHash:
+    """BlockService.get_block_by_hash."""
+
+    def test_returns_block_when_found(self):
+        """Debe retornar el bloque cuando MongoDB lo encuentra por hash."""
+        with patch("src.services.block_service.get_blocks_collection") as mock_col_fn:
+            mock_col_fn.return_value.find_one.return_value = SAMPLE_BLOCK_DOC
+            from src.services.block_service import BlockService
+            service = BlockService()
+
+            result = service.get_block_by_hash("b" * 64)
+
+            assert result is not None
+
+    def test_returns_none_when_not_found(self):
+        """Debe retornar None si el hash no corresponde a ningún bloque."""
+        with patch("src.services.block_service.get_blocks_collection") as mock_col_fn:
+            mock_col_fn.return_value.find_one.return_value = None
+            from src.services.block_service import BlockService
+            service = BlockService()
+
+            result = service.get_block_by_hash("z" * 64)
+
+            assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_chain_stats
+# ---------------------------------------------------------------------------
+
+
+class TestGetChainStats:
+    """BlockService.get_chain_stats — estadísticas en tiempo real."""
+
+    def _make_stats_mock(self, blocks: list[dict], total: int, last_block_doc):
+        """Helper para crear un mock de colección apropiado para get_chain_stats."""
+        col = MagicMock()
+        col.count_documents.return_value = total
+
+        # find_one retorna el último bloque (timestamp)
+        col.find_one.return_value = last_block_doc
+
+        # find() retorna cursor iterable para acumular transacciones
+        cursor = MagicMock()
+        cursor.__iter__ = MagicMock(return_value=iter(blocks))
+        col.find.return_value = cursor
+
+        return col
+
+    def test_empty_chain_returns_zeros(self):
+        """Con cadena vacía, todos los contadores son 0 y last_block_time es None."""
+        with patch("src.services.block_service.get_blocks_collection") as mock_col_fn:
+            mock_col_fn.return_value = self._make_stats_mock(
+                blocks=[], total=0, last_block_doc=None
+            )
+            from src.services.block_service import BlockService
+            service = BlockService()
+
+            stats = service.get_chain_stats()
+
+            assert stats["total_blocks"] == 0
+            assert stats["last_block_time"] is None
+            assert stats["total_transactions"] == 0
+            assert stats["total_ufrocoins_emitidos"] == 0.0
+
+    def test_stats_with_one_block_two_transactions(self):
+        """Un bloque con 2 transacciones debe acumular correctamente."""
+        block = {
+            "transactions": [
+                {"from": "a", "to": "b", "amount": 100.0},
+                {"from": "c", "to": "d", "amount": 50.0},
+            ]
+        }
+        last_doc = {"timestamp": "2026-04-10T10:00:00Z"}
+
+        with patch("src.services.block_service.get_blocks_collection") as mock_col_fn:
+            mock_col_fn.return_value = self._make_stats_mock(
+                blocks=[block], total=1, last_block_doc=last_doc
+            )
+            from src.services.block_service import BlockService
+            service = BlockService()
+
+            stats = service.get_chain_stats()
+
+            assert stats["total_blocks"] == 1
+            assert stats["last_block_time"] == "2026-04-10T10:00:00Z"
+            assert stats["total_transactions"] == 2
+            assert stats["total_ufrocoins_emitidos"] == pytest.approx(150.0)
+
+    def test_non_dict_transactions_are_discarded(self):
+        """Las transacciones que no sean dicts (e.g. strings, None) deben ignorarse."""
+        block = {
+            "transactions": [
+                {"from": "a", "to": "b", "amount": 10.0},
+                "invalid_string_tx",
+                None,
+            ]
+        }
+        with patch("src.services.block_service.get_blocks_collection") as mock_col_fn:
+            mock_col_fn.return_value = self._make_stats_mock(
+                blocks=[block], total=1, last_block_doc={"timestamp": "2026-04-10T10:00:00Z"}
+            )
+            from src.services.block_service import BlockService
+            service = BlockService()
+
+            stats = service.get_chain_stats()
+
+            assert stats["total_transactions"] == 1
+            assert stats["total_ufrocoins_emitidos"] == pytest.approx(10.0)
+
+    def test_missing_amount_defaults_to_zero(self):
+        """Una transacción sin 'amount' no debe romper el acumulado (cuenta como 0.0)."""
+        block = {"transactions": [{"from": "a", "to": "b"}]}
+        with patch("src.services.block_service.get_blocks_collection") as mock_col_fn:
+            mock_col_fn.return_value = self._make_stats_mock(
+                blocks=[block], total=1, last_block_doc={"timestamp": "2026-04-10T10:00:00Z"}
+            )
+            from src.services.block_service import BlockService
+            service = BlockService()
+
+            stats = service.get_chain_stats()
+
+            assert stats["total_transactions"] == 1
+            assert stats["total_ufrocoins_emitidos"] == pytest.approx(0.0)
+
+    def test_multiple_blocks_accumulate_correctly(self):
+        """Múltiples bloques deben acumular todas sus transacciones."""
+        block1 = {"transactions": [{"from": "a", "to": "b", "amount": 100.0}]}
+        block2 = {"transactions": [{"from": "c", "to": "d", "amount": 200.0},
+                                    {"from": "e", "to": "f", "amount": 300.0}]}
+
+        with patch("src.services.block_service.get_blocks_collection") as mock_col_fn:
+            mock_col_fn.return_value = self._make_stats_mock(
+                blocks=[block1, block2], total=2, last_block_doc={"timestamp": "2026-04-10T10:00:00Z"}
+            )
+            from src.services.block_service import BlockService
+            service = BlockService()
+
+            stats = service.get_chain_stats()
+
+            assert stats["total_transactions"] == 3
+            assert stats["total_ufrocoins_emitidos"] == pytest.approx(600.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _with_confirmed_transaction_indexes (método estático)
+# ---------------------------------------------------------------------------
+
+
+class TestWithConfirmedTransactionIndexes:
+    """BlockService._with_confirmed_transaction_indexes — enriquece transacciones."""
+
+    def test_injects_block_index_into_transactions(self):
+        """Cada transacción debe recibir el block_index del bloque contenedor."""
+        from src.services.block_service import BlockService
+
+        block = {
+            "index": 3,
+            "timestamp": "2026-04-10T10:00:00Z",
+            "transactions": [{"id": "tx-1", "from": "a", "to": "b", "amount": 10.0}],
+        }
+        result = BlockService._with_confirmed_transaction_indexes(block)
+
+        assert result["transactions"][0]["block_index"] == 3
+
+    def test_sets_status_confirmed(self):
+        """Las transacciones sin status deben recibir status=CONFIRMED."""
+        from src.services.block_service import BlockService
+
+        block = {
+            "index": 1,
+            "transactions": [{"id": "tx-1", "amount": 5.0}],
+        }
+        result = BlockService._with_confirmed_transaction_indexes(block)
+
+        assert result["transactions"][0]["status"] == "CONFIRMED"
+
+    def test_preserves_existing_status(self):
+        """Si la transacción ya tiene status, se usa el valor existente (setdefault)."""
+        from src.services.block_service import BlockService
+
+        block = {
+            "index": 2,
+            "transactions": [{"id": "tx-1", "status": "MINING_REWARD", "amount": 50.0}],
+        }
+        result = BlockService._with_confirmed_transaction_indexes(block)
+
+        assert result["transactions"][0]["status"] == "MINING_REWARD"
+
+    def test_non_dict_transactions_passed_through(self):
+        """Valores no-dict en transactions (anomalías) se pasan sin modificar."""
+        from src.services.block_service import BlockService
+
+        block = {
+            "index": 1,
+            "transactions": ["invalid_value"],
+        }
+        result = BlockService._with_confirmed_transaction_indexes(block)
+
+        assert result["transactions"][0] == "invalid_value"
+
+    def test_empty_transactions_list(self):
+        """Un bloque sin transacciones produce transactions=[]."""
+        from src.services.block_service import BlockService
+
+        block = {"index": 0, "transactions": []}
+        result = BlockService._with_confirmed_transaction_indexes(block)
+
+        assert result["transactions"] == []
+
+    def test_does_not_mutate_original_block(self):
+        """La función retorna una copia; el dict original no se modifica."""
+        from src.services.block_service import BlockService
+
+        original_tx = {"id": "tx-1", "amount": 10.0}
+        block = {"index": 1, "transactions": [original_tx]}
+        _ = BlockService._with_confirmed_transaction_indexes(block)
+
+        # La transacción original no debe tener block_index
+        assert "block_index" not in original_tx

--- a/test/test_block_validation_service.py
+++ b/test/test_block_validation_service.py
@@ -1,0 +1,322 @@
+"""
+Tests unitarios para src.services.block_validation_service.BlockValidationService.
+
+Estrategia:
+- validate_block_integrity: usa datos reales (hashes calculados con hash_utils) para
+  confirmar que el servicio acepta bloques válidos y rechaza bloques corruptos.
+- validate_chain_integrity: mockea la colección MongoDB para evitar dependencia de infra.
+- Se testea también _is_iso_8601_datetime (función de módulo) de forma directa.
+"""
+
+import hashlib
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.core.constants import GENESIS_BLOCK_INDEX, GENESIS_PREVIOUS_HASH
+from src.services.block_validation_service import (
+    BlockValidationService,
+    _is_iso_8601_datetime,
+)
+from src.utils.hash_utils import (
+    calculate_concatenated_block_hash,
+    serialize_block_fields_for_concatenation,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers para construir bloques con hashes reales
+# ---------------------------------------------------------------------------
+
+
+def _build_non_genesis_hash(block_data: dict) -> str:
+    """Recalcula el hash SHA-256 JSON-based para un bloque no-génesis."""
+    payload = {
+        "index": block_data["index"],
+        "timestamp": block_data["timestamp"],
+        "transactions": block_data["transactions"],
+        "previous_hash": block_data["previous_hash"],
+        "nonce": block_data["nonce"],
+    }
+    serialized = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def make_valid_genesis_block() -> dict:
+    """Construye un bloque génesis cuyo hash es correcto (calculado con concatenación)."""
+    block = {
+        "index": GENESIS_BLOCK_INDEX,
+        "timestamp": "2026-04-09T12:00:00Z",
+        "transactions": [
+            {
+                "tx_id": "genesis-abc",
+                "type": "GENESIS_ISSUANCE",
+                "from_address": "SYSTEM",
+                "to_address": "REWARD_POOL",
+                "amount": 1_000_000,
+            }
+        ],
+        "previous_hash": GENESIS_PREVIOUS_HASH,
+        "nonce": 0,
+    }
+    block["hash"] = calculate_concatenated_block_hash(block)
+    return block
+
+
+def make_valid_non_genesis_block(previous_hash: str, index: int = 1) -> dict:
+    """Construye un bloque no-génesis cuyo hash es correcto (SHA-256 JSON-based)."""
+    block = {
+        "index": index,
+        "timestamp": "2026-04-10T10:00:00Z",
+        "transactions": [],
+        "previous_hash": previous_hash,
+        "nonce": 48271,
+    }
+    block["hash"] = _build_non_genesis_hash(block)
+    return block
+
+
+# ---------------------------------------------------------------------------
+# _is_iso_8601_datetime (función de módulo)
+# ---------------------------------------------------------------------------
+
+
+class TestIsIso8601Datetime:
+    """Validación del formato ISO 8601 para el campo timestamp del bloque."""
+
+    def test_valid_utc_z_suffix(self):
+        """Timestamps terminando en Z son válidos."""
+        assert _is_iso_8601_datetime("2026-04-09T12:00:00Z") is True
+
+    def test_valid_with_offset(self):
+        """Timestamps con offset de zona horaria son válidos."""
+        assert _is_iso_8601_datetime("2026-04-09T12:00:00+00:00") is True
+
+    def test_valid_with_negative_offset(self):
+        """Timestamps con offset negativo son válidos."""
+        assert _is_iso_8601_datetime("2026-06-01T08:00:00-04:00") is True
+
+    def test_invalid_without_T(self):
+        """Una cadena sin 'T' que separe fecha y hora no es válida."""
+        assert _is_iso_8601_datetime("2026-04-09 12:00:00") is False
+
+    def test_invalid_plain_date(self):
+        """Una fecha sin hora no es válida."""
+        assert _is_iso_8601_datetime("2026-04-09") is False
+
+    def test_invalid_garbage_string(self):
+        """Una cadena arbitraria no es válida."""
+        assert _is_iso_8601_datetime("not-a-date") is False
+
+    def test_invalid_partial_datetime(self):
+        """Una cadena con T pero formato incompleto no es válida."""
+        assert _is_iso_8601_datetime("2026-04T12") is False
+
+
+# ---------------------------------------------------------------------------
+# validate_block_integrity
+# ---------------------------------------------------------------------------
+
+
+class TestValidateBlockIntegrity:
+    """Tests para BlockValidationService.validate_block_integrity."""
+
+    service = BlockValidationService()
+
+    def test_valid_genesis_block_returns_true(self):
+        """Un bloque génesis con hash correcto debe retornar True."""
+        block = make_valid_genesis_block()
+        assert self.service.validate_block_integrity(block) is True
+
+    def test_valid_non_genesis_block_returns_true(self):
+        """Un bloque no-génesis con hash correcto debe retornar True."""
+        genesis = make_valid_genesis_block()
+        block = make_valid_non_genesis_block(previous_hash=genesis["hash"])
+        assert self.service.validate_block_integrity(block) is True
+
+    def test_tampered_hash_returns_false(self):
+        """Si el hash almacenado fue manipulado, debe retornar False."""
+        block = make_valid_genesis_block()
+        block["hash"] = "a" * 64  # hash incorrecto pero hex-64 válido
+        assert self.service.validate_block_integrity(block) is False
+
+    def test_missing_required_field_returns_false(self):
+        """Un bloque al que le falta un campo requerido debe retornar False."""
+        block = make_valid_genesis_block()
+        del block["nonce"]
+        assert self.service.validate_block_integrity(block) is False
+
+    def test_invalid_timestamp_format_returns_false(self):
+        """Un timestamp sin 'T' retorna False."""
+        block = make_valid_genesis_block()
+        block["timestamp"] = "2026-04-09 12:00:00"
+        assert self.service.validate_block_integrity(block) is False
+
+    def test_index_as_bool_returns_false(self):
+        """Un bool en el campo index es rechazado (bool es subclase de int)."""
+        block = make_valid_genesis_block()
+        block["index"] = True
+        assert self.service.validate_block_integrity(block) is False
+
+    def test_nonce_as_bool_returns_false(self):
+        """Un bool en el campo nonce es rechazado."""
+        block = make_valid_genesis_block()
+        block["nonce"] = False
+        assert self.service.validate_block_integrity(block) is False
+
+    def test_non_hex_hash_returns_false(self):
+        """Un hash con caracteres no hexadecimales retorna False."""
+        block = make_valid_genesis_block()
+        block["hash"] = "z" * 64
+        assert self.service.validate_block_integrity(block) is False
+
+    def test_short_hash_returns_false(self):
+        """Un hash con menos de 64 caracteres retorna False."""
+        block = make_valid_genesis_block()
+        block["hash"] = "abc123"
+        assert self.service.validate_block_integrity(block) is False
+
+    def test_transactions_not_a_list_returns_false(self):
+        """El campo transactions debe ser una lista; un dict retorna False."""
+        block = make_valid_genesis_block()
+        block["transactions"] = {"invalid": "value"}
+        assert self.service.validate_block_integrity(block) is False
+
+    def test_accepts_block_validation_request_model(self):
+        """También acepta un BlockValidationRequest de Pydantic (no solo dict)."""
+        from src.models.block import BlockValidationRequest
+
+        block_dict = make_valid_non_genesis_block(previous_hash="a" * 64)
+        request = BlockValidationRequest(**block_dict)
+        assert self.service.validate_block_integrity(request) is True
+
+    def test_empty_dict_returns_false(self):
+        """Un dict vacío retorna False."""
+        assert self.service.validate_block_integrity({}) is False
+
+
+# ---------------------------------------------------------------------------
+# validate_chain_integrity
+# ---------------------------------------------------------------------------
+
+
+def _make_db_with_blocks(blocks: list[dict]) -> MagicMock:
+    """Construye un db mock cuya colección 'blocks' retorna los bloques dados."""
+    db_client = MagicMock()
+    db = MagicMock()
+    db_client.__getitem__.return_value = db
+
+    # El cursor debe ordenarse: se mockea el método sort() retornando los bloques directamente
+    cursor = MagicMock()
+    cursor.__iter__ = MagicMock(return_value=iter(blocks))
+    db.__getitem__.return_value.find.return_value.sort.return_value = cursor
+
+    return db_client
+
+
+class TestValidateChainIntegrity:
+    """Tests para BlockValidationService.validate_chain_integrity con DB mockeada."""
+
+    def test_raises_runtime_error_without_db(self):
+        """Sin conexión de DB, validate_chain_integrity lanza RuntimeError."""
+        service = BlockValidationService()  # sin db_client
+        with pytest.raises(RuntimeError, match="requires a database connection"):
+            service.validate_chain_integrity()
+
+    def test_empty_chain_is_valid(self):
+        """Una blockchain vacía retorna chain_valid=True y total_blocks=0."""
+        db_client = _make_db_with_blocks([])
+        service = BlockValidationService(db_client=db_client, db_name="ufrocoin")
+
+        result = service.validate_chain_integrity()
+
+        assert result["chain_valid"] is True
+        assert result["total_blocks"] == 0
+        assert result["blocks"] == []
+        assert result["error_at_block"] is None
+
+    def test_single_valid_genesis_block(self):
+        """Una cadena de un solo bloque génesis válido es íntegra."""
+        genesis = make_valid_genesis_block()
+        db_client = _make_db_with_blocks([genesis])
+        service = BlockValidationService(db_client=db_client, db_name="ufrocoin")
+
+        result = service.validate_chain_integrity()
+
+        assert result["chain_valid"] is True
+        assert result["total_blocks"] == 1
+        assert result["blocks"][0]["valid"] is True
+        assert result["error_at_block"] is None
+
+    def test_two_valid_linked_blocks(self):
+        """Una cadena de dos bloques correctamente enlazados es íntegra."""
+        genesis = make_valid_genesis_block()
+        block1 = make_valid_non_genesis_block(previous_hash=genesis["hash"], index=1)
+
+        db_client = _make_db_with_blocks([genesis, block1])
+        service = BlockValidationService(db_client=db_client, db_name="ufrocoin")
+
+        result = service.validate_chain_integrity()
+
+        assert result["chain_valid"] is True
+        assert result["total_blocks"] == 2
+        assert result["error_at_block"] is None
+
+    def test_tampered_hash_invalidates_chain(self):
+        """Un hash manipulado en un bloque marca la cadena como inválida."""
+        genesis = make_valid_genesis_block()
+        block1 = make_valid_non_genesis_block(previous_hash=genesis["hash"], index=1)
+        block1["hash"] = "d" * 64  # hash corrupto pero hex-64 válido
+
+        db_client = _make_db_with_blocks([genesis, block1])
+        service = BlockValidationService(db_client=db_client, db_name="ufrocoin")
+
+        result = service.validate_chain_integrity()
+
+        assert result["chain_valid"] is False
+        assert result["error_at_block"] == 1
+
+    def test_broken_previous_hash_link_invalidates_chain(self):
+        """Un previous_hash que no coincide con el hash del bloque anterior invalida la cadena."""
+        genesis = make_valid_genesis_block()
+        block1 = make_valid_non_genesis_block(previous_hash="e" * 64, index=1)
+        # Recalcula hash con el previous_hash falso (para que la integridad individual pase)
+
+        db_client = _make_db_with_blocks([genesis, block1])
+        service = BlockValidationService(db_client=db_client, db_name="ufrocoin")
+
+        result = service.validate_chain_integrity()
+
+        # El enlace entre génesis y bloque1 está roto
+        assert result["chain_valid"] is False
+
+    def test_result_includes_computed_and_stored_hash(self):
+        """El resultado por bloque incluye stored_hash, computed_hash e index."""
+        genesis = make_valid_genesis_block()
+        db_client = _make_db_with_blocks([genesis])
+        service = BlockValidationService(db_client=db_client, db_name="ufrocoin")
+
+        result = service.validate_chain_integrity()
+
+        block_result = result["blocks"][0]
+        assert "index" in block_result
+        assert "stored_hash" in block_result
+        assert "computed_hash" in block_result
+        assert "valid" in block_result
+
+    def test_first_corrupted_block_is_reported(self):
+        """error_at_block señala el índice del PRIMER bloque corrupto, no el último."""
+        genesis = make_valid_genesis_block()
+        block1 = make_valid_non_genesis_block(previous_hash=genesis["hash"], index=1)
+        block2 = make_valid_non_genesis_block(previous_hash=block1["hash"], index=2)
+
+        # Corromper bloque 1 (el del medio)
+        corrupted_block1 = {**block1, "hash": "f" * 64}
+
+        db_client = _make_db_with_blocks([genesis, corrupted_block1, block2])
+        service = BlockValidationService(db_client=db_client, db_name="ufrocoin")
+
+        result = service.validate_chain_integrity()
+
+        assert result["error_at_block"] == 1  # bloque con index=1 es el primero corrupto

--- a/test/test_genesis_service.py
+++ b/test/test_genesis_service.py
@@ -1,0 +1,357 @@
+"""
+Tests unitarios para src.services.genesis_service.GenesisService.
+
+Estrategia:
+- Se mockean BlockService, la colección chain_metadata y publish_event para
+  evitar dependencia de MongoDB y RabbitMQ.
+- Se verifica la lógica de control de flujo (idempotencia del génesis,
+  sincronización de metadata, manejo de errores de publicación).
+- Se testean build_genesis_transaction y build_genesis_block de forma aislada
+  verificando sus valores criptográficos.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.core.constants import (
+    GENESIS_BLOCK_INDEX,
+    GENESIS_PREVIOUS_HASH,
+    GENESIS_TRANSACTION_TYPE,
+    REWARD_POOL,
+    SYSTEM_ADDRESS,
+    SYSTEM_REWARD,
+)
+from src.utils.hash_utils import calculate_concatenated_block_hash
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_genesis_service(
+    metadata_doc=None,
+    last_block=None,
+    insert_raises=None,
+) -> "GenesisService":  # noqa: F821
+    """
+    Construye un GenesisService con todas las dependencias externas mockeadas.
+
+    Parámetros:
+        metadata_doc: documento retornado por chain_metadata.find_one.
+        last_block: documento retornado por BlockService.get_last_block.
+        insert_raises: excepción que lanza BlockService.create_genesis_block.
+    """
+    with (
+        patch("src.services.genesis_service.get_chain_metadata_collection") as mock_meta_col,
+        patch("src.services.genesis_service.BlockService") as MockBlockService,
+        patch("src.services.genesis_service.publish_event"),
+    ):
+        # Configurar chain_metadata mock
+        meta_collection = MagicMock()
+        meta_collection.find_one.return_value = metadata_doc
+        mock_meta_col.return_value = meta_collection
+
+        # Configurar BlockService mock
+        mock_bs_instance = MagicMock()
+        mock_bs_instance.get_last_block.return_value = last_block
+        mock_bs_instance.blocks_collection.count_documents.return_value = 1
+
+        if insert_raises:
+            mock_bs_instance.create_genesis_block.side_effect = insert_raises
+        else:
+            # save devuelve un documento simulado con hash
+            mock_bs_instance.create_genesis_block.side_effect = lambda block: None
+
+        MockBlockService.return_value = mock_bs_instance
+
+        from src.services.genesis_service import GenesisService
+
+        service = GenesisService()
+        # Inyectar los mocks en el servicio para que los tests puedan inspeccionarlos
+        service._mock_meta_collection = meta_collection
+        service._mock_block_service = mock_bs_instance
+        return service
+
+
+# ---------------------------------------------------------------------------
+# Tests: create_genesis_if_needed — control de flujo
+# ---------------------------------------------------------------------------
+
+
+class TestCreateGenesisIfNeeded:
+    """GenesisService.create_genesis_if_needed — lógica de idempotencia."""
+
+    def test_returns_none_when_genesis_already_created(self):
+        """Si metadata indica genesis_created=True, no crea nada y retorna None."""
+        with (
+            patch("src.services.genesis_service.get_chain_metadata_collection") as mock_meta,
+            patch("src.services.genesis_service.BlockService") as MockBS,
+            patch("src.services.genesis_service.publish_event"),
+        ):
+            mock_meta.return_value.find_one.return_value = {"genesis_created": True}
+            from src.services.genesis_service import GenesisService
+
+            service = GenesisService()
+            result = service.create_genesis_if_needed()
+
+            assert result is None
+            MockBS.return_value.create_genesis_block.assert_not_called()
+
+    def test_returns_none_when_chain_already_has_blocks(self):
+        """Si ya existe un bloque en la cadena, sincroniza metadata y retorna None."""
+        existing_block = {
+            "index": 5,
+            "hash": "e" * 64,
+            "timestamp": "2026-04-09T12:00:00Z",
+        }
+        with (
+            patch("src.services.genesis_service.get_chain_metadata_collection") as mock_meta,
+            patch("src.services.genesis_service.BlockService") as MockBS,
+            patch("src.services.genesis_service.publish_event"),
+        ):
+            mock_meta.return_value.find_one.return_value = None  # sin metadata
+            mock_bs = MagicMock()
+            mock_bs.get_last_block.return_value = existing_block
+            mock_bs.blocks_collection.count_documents.return_value = 6
+            MockBS.return_value = mock_bs
+
+            from src.services.genesis_service import GenesisService
+
+            service = GenesisService()
+            result = service.create_genesis_if_needed()
+
+            assert result is None
+            mock_bs.create_genesis_block.assert_not_called()
+
+    def test_creates_genesis_block_when_chain_is_empty(self):
+        """Si no hay metadata ni bloques, debe crear el bloque génesis."""
+        captured_block = {}
+
+        def fake_create(block):
+            captured_block["block"] = block
+
+        with (
+            patch("src.services.genesis_service.get_chain_metadata_collection") as mock_meta,
+            patch("src.services.genesis_service.BlockService") as MockBS,
+            patch("src.services.genesis_service.publish_event"),
+        ):
+            mock_meta.return_value.find_one.return_value = None
+            mock_bs = MagicMock()
+            mock_bs.get_last_block.return_value = None
+            mock_bs.create_genesis_block.side_effect = fake_create
+            MockBS.return_value = mock_bs
+
+            from src.services.genesis_service import GenesisService
+
+            service = GenesisService()
+            result = service.create_genesis_if_needed()
+
+            # Debe haber llamado create_genesis_block
+            assert mock_bs.create_genesis_block.called
+
+    def test_handles_duplicate_key_error_gracefully(self):
+        """Si create_genesis_block lanza DuplicateKeyError, retorna None sin relanzar."""
+        try:
+            from pymongo.errors import DuplicateKeyError
+            dup_error = DuplicateKeyError("duplicate", code=11000)
+        except ImportError:
+            pytest.skip("pymongo no disponible")
+
+        with (
+            patch("src.services.genesis_service.get_chain_metadata_collection") as mock_meta,
+            patch("src.services.genesis_service.BlockService") as MockBS,
+            patch("src.services.genesis_service.publish_event"),
+        ):
+            mock_meta.return_value.find_one.return_value = None
+            mock_bs = MagicMock()
+            mock_bs.get_last_block.return_value = None
+            mock_bs.create_genesis_block.side_effect = dup_error
+            MockBS.return_value = mock_bs
+
+            from src.services.genesis_service import GenesisService
+
+            service = GenesisService()
+            # No debe lanzar excepción
+            result = service.create_genesis_if_needed()
+            assert result is None
+
+    def test_rabbitmq_failure_does_not_propagate(self):
+        """Si publish_event falla, el error se silencia y el método retorna igualmente."""
+        with (
+            patch("src.services.genesis_service.get_chain_metadata_collection") as mock_meta,
+            patch("src.services.genesis_service.BlockService") as MockBS,
+            patch("src.services.genesis_service.publish_event", side_effect=RuntimeError("RabbitMQ down")),
+        ):
+            mock_meta.return_value.find_one.return_value = None
+            mock_bs = MagicMock()
+            mock_bs.get_last_block.return_value = None
+            MockBS.return_value = mock_bs
+
+            from src.services.genesis_service import GenesisService
+
+            service = GenesisService()
+            # No debe propagar la excepción de RabbitMQ
+            try:
+                service.create_genesis_if_needed()
+            except RuntimeError:
+                pytest.fail("publish_event failure was not silenced")
+
+    def test_metadata_is_updated_after_genesis_creation(self):
+        """Después de crear el génesis, se llama update_one en chain_metadata."""
+        with (
+            patch("src.services.genesis_service.get_chain_metadata_collection") as mock_meta,
+            patch("src.services.genesis_service.BlockService") as MockBS,
+            patch("src.services.genesis_service.publish_event"),
+        ):
+            mock_meta.return_value.find_one.return_value = None
+            mock_bs = MagicMock()
+            mock_bs.get_last_block.return_value = None
+            MockBS.return_value = mock_bs
+
+            from src.services.genesis_service import GenesisService
+
+            service = GenesisService()
+            service.create_genesis_if_needed()
+
+            mock_meta.return_value.update_one.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests: build_genesis_transaction
+# ---------------------------------------------------------------------------
+
+
+class TestBuildGenesisTransaction:
+    """GenesisService.build_genesis_transaction — estructura de la transacción inicial."""
+
+    def _get_service(self):
+        with (
+            patch("src.services.genesis_service.get_chain_metadata_collection"),
+            patch("src.services.genesis_service.BlockService"),
+        ):
+            from src.services.genesis_service import GenesisService
+            return GenesisService()
+
+    def test_type_is_genesis_issuance(self):
+        """El tipo debe ser GENESIS_ISSUANCE."""
+        service = self._get_service()
+        tx = service.build_genesis_transaction()
+        assert tx["type"] == GENESIS_TRANSACTION_TYPE
+
+    def test_from_address_is_system(self):
+        """La dirección de origen debe ser SYSTEM."""
+        service = self._get_service()
+        tx = service.build_genesis_transaction()
+        assert tx["from_address"] == SYSTEM_ADDRESS
+
+    def test_to_address_is_reward_pool(self):
+        """La dirección de destino debe ser REWARD_POOL."""
+        service = self._get_service()
+        tx = service.build_genesis_transaction()
+        assert tx["to_address"] == REWARD_POOL
+
+    def test_amount_is_system_reward(self):
+        """El monto debe ser el SYSTEM_REWARD (1_000_000)."""
+        service = self._get_service()
+        tx = service.build_genesis_transaction()
+        assert tx["amount"] == SYSTEM_REWARD
+
+    def test_has_tx_id(self):
+        """La transacción debe incluir un tx_id generado dinámicamente."""
+        service = self._get_service()
+        tx = service.build_genesis_transaction()
+        assert "tx_id" in tx
+        assert tx["tx_id"].startswith("genesis-")
+
+    def test_tx_id_is_unique(self):
+        """Cada llamada genera un tx_id único."""
+        service = self._get_service()
+        tx1 = service.build_genesis_transaction()
+        tx2 = service.build_genesis_transaction()
+        assert tx1["tx_id"] != tx2["tx_id"]
+
+    def test_has_timestamp(self):
+        """La transacción debe incluir un timestamp ISO 8601 terminando en Z."""
+        service = self._get_service()
+        tx = service.build_genesis_transaction()
+        assert "timestamp" in tx
+        assert tx["timestamp"].endswith("Z")
+
+    def test_metadata_has_reason(self):
+        """El campo metadata debe contener la razón initial_system_issuance."""
+        service = self._get_service()
+        tx = service.build_genesis_transaction()
+        assert tx.get("metadata", {}).get("reason") == "initial_system_issuance"
+
+
+# ---------------------------------------------------------------------------
+# Tests: build_genesis_block
+# ---------------------------------------------------------------------------
+
+
+class TestBuildGenesisBlock:
+    """GenesisService.build_genesis_block — construcción criptográfica del bloque génesis."""
+
+    def _get_service(self):
+        with (
+            patch("src.services.genesis_service.get_chain_metadata_collection"),
+            patch("src.services.genesis_service.BlockService"),
+        ):
+            from src.services.genesis_service import GenesisService
+            return GenesisService()
+
+    def test_index_is_genesis_block_index(self):
+        """El índice del bloque génesis debe ser GENESIS_BLOCK_INDEX (0)."""
+        service = self._get_service()
+        tx = service.build_genesis_transaction()
+        block = service.build_genesis_block(tx)
+        assert block.index == GENESIS_BLOCK_INDEX
+
+    def test_previous_hash_is_genesis_previous_hash(self):
+        """El previous_hash del génesis debe ser 64 ceros."""
+        service = self._get_service()
+        tx = service.build_genesis_transaction()
+        block = service.build_genesis_block(tx)
+        assert block.previous_hash == GENESIS_PREVIOUS_HASH
+
+    def test_hash_is_not_none(self):
+        """El bloque génesis debe tener un hash calculado (no None)."""
+        service = self._get_service()
+        tx = service.build_genesis_transaction()
+        block = service.build_genesis_block(tx)
+        assert block.hash is not None
+
+    def test_hash_matches_concatenated_hash(self):
+        """El hash del bloque debe coincidir con calculate_concatenated_block_hash."""
+        service = self._get_service()
+        tx = service.build_genesis_transaction()
+        block = service.build_genesis_block(tx)
+
+        expected_hash = calculate_concatenated_block_hash(block.model_dump(exclude_none=True))
+        assert block.hash == expected_hash
+
+    def test_hash_is_64_hex_chars(self):
+        """El hash debe ser una cadena hexadecimal de exactamente 64 caracteres."""
+        service = self._get_service()
+        tx = service.build_genesis_transaction()
+        block = service.build_genesis_block(tx)
+
+        assert len(block.hash) == 64
+        assert all(c in "0123456789abcdef" for c in block.hash)
+
+    def test_nonce_is_zero(self):
+        """El nonce del bloque génesis debe ser 0."""
+        service = self._get_service()
+        tx = service.build_genesis_transaction()
+        block = service.build_genesis_block(tx)
+        assert block.nonce == 0
+
+    def test_contains_genesis_transaction(self):
+        """El bloque génesis debe contener exactamente una transacción (la génesis)."""
+        service = self._get_service()
+        tx = service.build_genesis_transaction()
+        block = service.build_genesis_block(tx)
+        assert len(block.transactions) == 1
+        assert block.transactions[0] == tx

--- a/test/test_hash_utils.py
+++ b/test/test_hash_utils.py
@@ -1,0 +1,349 @@
+"""
+Tests unitarios para src.utils.hash_utils.
+
+Estrategia:
+- Sin mocks: todas las funciones son puras (sin I/O ni estado externo).
+- Se verifican propiedades matemáticas: determinismo, idempotencia, y que
+  cambios mínimos en el input produzcan un hash distinto (efecto avalancha).
+- Los valores de hash esperados se calculan una vez de forma manual y se usan
+  como constantes para anclar la implementación.
+"""
+
+import hashlib
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from src.utils.hash_utils import (
+    _normalize_value,
+    calculate_block_hash,
+    calculate_concatenated_block_hash,
+    serialize_block_fields_for_concatenation,
+    serialize_block_for_hash,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers de test
+# ---------------------------------------------------------------------------
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# _normalize_value
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeValue:
+    """Normalización recursiva de valores para serialización determinística."""
+
+    def test_string_passthrough(self):
+        """Strings simples no se alteran."""
+        assert _normalize_value("hello") == "hello"
+
+    def test_int_passthrough(self):
+        """Enteros no se alteran."""
+        assert _normalize_value(42) == 42
+
+    def test_float_passthrough(self):
+        """Floats no se alteran."""
+        assert _normalize_value(3.14) == 3.14
+
+    def test_none_passthrough(self):
+        """None no se altera."""
+        assert _normalize_value(None) is None
+
+    def test_datetime_aware_utc(self):
+        """Un datetime con timezone UTC se serializa a ISO 8601 terminando en Z."""
+        dt = datetime(2026, 4, 9, 12, 0, 0, tzinfo=timezone.utc)
+        result = _normalize_value(dt)
+        assert result == "2026-04-09T12:00:00Z"
+
+    def test_datetime_naive_treated_as_utc(self):
+        """Un datetime naive se trata como UTC y termina en Z."""
+        dt = datetime(2026, 4, 9, 12, 0, 0)  # sin tzinfo
+        result = _normalize_value(dt)
+        assert result == "2026-04-09T12:00:00Z"
+
+    def test_dict_excludes_id_key(self):
+        """El campo _id es excluido del dict normalizado."""
+        data = {"_id": "some_mongo_id", "index": 1}
+        result = _normalize_value(data)
+        assert "_id" not in result
+        assert result["index"] == 1
+
+    def test_dict_excludes_hash_key(self):
+        """El campo hash es excluido del dict normalizado."""
+        data = {"hash": "abc123", "index": 0}
+        result = _normalize_value(data)
+        assert "hash" not in result
+        assert result["index"] == 0
+
+    def test_dict_keeps_other_keys(self):
+        """Los demás campos del dict se preservan."""
+        data = {"nonce": 99, "previous_hash": "0" * 64, "_id": "drop"}
+        result = _normalize_value(data)
+        assert result["nonce"] == 99
+        assert result["previous_hash"] == "0" * 64
+
+    def test_nested_dict(self):
+        """La normalización es recursiva sobre dicts anidados."""
+        data = {"tx": {"_id": "drop", "amount": 10.0}}
+        result = _normalize_value(data)
+        assert "_id" not in result["tx"]
+        assert result["tx"]["amount"] == 10.0
+
+    def test_list_normalizes_each_element(self):
+        """La normalización es recursiva sobre listas."""
+        data = [{"_id": "drop", "value": 1}, {"_id": "drop", "value": 2}]
+        result = _normalize_value(data)
+        assert result == [{"value": 1}, {"value": 2}]
+
+    def test_empty_dict(self):
+        """Un dict vacío permanece vacío."""
+        assert _normalize_value({}) == {}
+
+    def test_empty_list(self):
+        """Una lista vacía permanece vacía."""
+        assert _normalize_value([]) == []
+
+
+# ---------------------------------------------------------------------------
+# serialize_block_for_hash
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeBlockForHash:
+    """Serialización JSON determinística eliminando _id y hash."""
+
+    BLOCK = {
+        "_id": "mongo_internal_id",
+        "index": 1,
+        "timestamp": "2026-04-10T10:00:00Z",
+        "transactions": [],
+        "previous_hash": "a" * 64,
+        "nonce": 12345,
+        "hash": "b" * 64,
+    }
+
+    def test_excludes_id_and_hash(self):
+        """La serialización no contiene _id ni hash."""
+        result = serialize_block_for_hash(self.BLOCK)
+        parsed = json.loads(result)
+        assert "_id" not in parsed
+        assert "hash" not in parsed
+
+    def test_contains_required_fields(self):
+        """La serialización contiene index, timestamp, transactions, previous_hash, nonce."""
+        result = serialize_block_for_hash(self.BLOCK)
+        parsed = json.loads(result)
+        for field in ("index", "timestamp", "transactions", "previous_hash", "nonce"):
+            assert field in parsed, f"Campo requerido ausente: {field}"
+
+    def test_is_deterministic(self):
+        """La misma entrada produce exactamente la misma salida."""
+        r1 = serialize_block_for_hash(self.BLOCK)
+        r2 = serialize_block_for_hash(self.BLOCK)
+        assert r1 == r2
+
+    def test_different_nonce_produces_different_output(self):
+        """Un cambio en un campo produce una serialización distinta."""
+        block_a = {**self.BLOCK, "nonce": 1}
+        block_b = {**self.BLOCK, "nonce": 2}
+        assert serialize_block_for_hash(block_a) != serialize_block_for_hash(block_b)
+
+    def test_keys_sorted(self):
+        """Las claves JSON están ordenadas alfabéticamente (sort_keys=True)."""
+        result = serialize_block_for_hash(self.BLOCK)
+        parsed = json.loads(result)
+        keys = list(parsed.keys())
+        assert keys == sorted(keys)
+
+    def test_no_spaces_in_separators(self):
+        """No hay espacios extra en separadores (compact JSON)."""
+        result = serialize_block_for_hash(self.BLOCK)
+        assert ": " not in result
+        assert ", " not in result
+
+
+# ---------------------------------------------------------------------------
+# serialize_block_fields_for_concatenation
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeBlockFieldsForConcatenation:
+    """Serialización por concatenación de campos para el bloque génesis."""
+
+    GENESIS_BLOCK = {
+        "index": 0,
+        "previous_hash": "0" * 64,
+        "timestamp": "2026-04-09T12:00:00Z",
+        "transactions": [
+            {
+                "tx_id": "genesis-001",
+                "type": "GENESIS_ISSUANCE",
+                "from_address": "SYSTEM",
+                "to_address": "REWARD_POOL",
+                "amount": 1_000_000,
+            }
+        ],
+        "nonce": 0,
+        "hash": "to_be_excluded",
+    }
+
+    def test_starts_with_index(self):
+        """La cadena concatenada comienza con el índice del bloque."""
+        result = serialize_block_fields_for_concatenation(self.GENESIS_BLOCK)
+        assert result.startswith("0")
+
+    def test_contains_previous_hash(self):
+        """La cadena contiene el previous_hash."""
+        result = serialize_block_fields_for_concatenation(self.GENESIS_BLOCK)
+        assert "0" * 64 in result
+
+    def test_contains_nonce(self):
+        """La cadena contiene el nonce al final."""
+        result = serialize_block_fields_for_concatenation(self.GENESIS_BLOCK)
+        assert result.endswith("0")
+
+    def test_is_deterministic(self):
+        """El mismo bloque produce exactamente la misma cadena."""
+        r1 = serialize_block_fields_for_concatenation(self.GENESIS_BLOCK)
+        r2 = serialize_block_fields_for_concatenation(self.GENESIS_BLOCK)
+        assert r1 == r2
+
+    def test_hash_excluded_from_transactions(self):
+        """El campo 'hash' del bloque no aparece en la cadena concatenada."""
+        result = serialize_block_fields_for_concatenation(self.GENESIS_BLOCK)
+        # "hash" excluido por _normalize_value
+        assert "to_be_excluded" not in result
+
+    def test_different_transactions_produce_different_output(self):
+        """Transacciones distintas producen cadenas distintas."""
+        block_a = {**self.GENESIS_BLOCK, "transactions": []}
+        block_b = {**self.GENESIS_BLOCK, "transactions": [{"id": "x", "amount": 1}]}
+        assert serialize_block_fields_for_concatenation(block_a) != \
+               serialize_block_fields_for_concatenation(block_b)
+
+
+# ---------------------------------------------------------------------------
+# calculate_block_hash
+# ---------------------------------------------------------------------------
+
+
+class TestCalculateBlockHash:
+    """SHA-256 basado en serialización JSON del bloque."""
+
+    BLOCK = {
+        "index": 1,
+        "timestamp": "2026-04-10T10:00:00Z",
+        "transactions": [],
+        "previous_hash": "a" * 64,
+        "nonce": 48271,
+    }
+
+    def test_returns_64_hex_characters(self):
+        """El hash resultante es una cadena hexadecimal de 64 caracteres."""
+        result = calculate_block_hash(self.BLOCK)
+        assert len(result) == 64
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_is_deterministic(self):
+        """El mismo bloque produce el mismo hash."""
+        assert calculate_block_hash(self.BLOCK) == calculate_block_hash(self.BLOCK)
+
+    def test_different_nonce_produces_different_hash(self):
+        """Un nonce distinto produce un hash distinto (efecto avalancha mínimo)."""
+        block_a = {**self.BLOCK, "nonce": 1}
+        block_b = {**self.BLOCK, "nonce": 2}
+        assert calculate_block_hash(block_a) != calculate_block_hash(block_b)
+
+    def test_different_index_produces_different_hash(self):
+        """Un índice distinto produce un hash distinto."""
+        block_a = {**self.BLOCK, "index": 1}
+        block_b = {**self.BLOCK, "index": 2}
+        assert calculate_block_hash(block_a) != calculate_block_hash(block_b)
+
+    def test_matches_manual_sha256(self):
+        """El resultado coincide con el SHA-256 calculado manualmente."""
+        serialized = serialize_block_for_hash(self.BLOCK)
+        expected = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+        assert calculate_block_hash(self.BLOCK) == expected
+
+    def test_id_field_excluded_from_hash(self):
+        """Agregar _id al bloque no cambia el hash (excluido en la serialización)."""
+        block_without_id = self.BLOCK.copy()
+        block_with_id = {**self.BLOCK, "_id": "some_mongo_id"}
+        assert calculate_block_hash(block_without_id) == calculate_block_hash(block_with_id)
+
+    def test_hash_field_excluded_from_hash(self):
+        """El campo hash no se incluye en el cálculo de hash (evita circularidad)."""
+        block_without_hash = self.BLOCK.copy()
+        block_with_hash = {**self.BLOCK, "hash": "old_hash_value"}
+        assert calculate_block_hash(block_without_hash) == calculate_block_hash(block_with_hash)
+
+
+# ---------------------------------------------------------------------------
+# calculate_concatenated_block_hash
+# ---------------------------------------------------------------------------
+
+
+class TestCalculateConcatenatedBlockHash:
+    """SHA-256 por concatenación de campos (usado en bloque génesis)."""
+
+    GENESIS_BLOCK = {
+        "index": 0,
+        "previous_hash": "0" * 64,
+        "timestamp": "2026-04-09T12:00:00Z",
+        "transactions": [
+            {
+                "tx_id": "genesis-001",
+                "type": "GENESIS_ISSUANCE",
+                "from_address": "SYSTEM",
+                "to_address": "REWARD_POOL",
+                "amount": 1_000_000,
+            }
+        ],
+        "nonce": 0,
+    }
+
+    def test_returns_64_hex_characters(self):
+        """El hash resultante es una cadena hexadecimal de 64 caracteres."""
+        result = calculate_concatenated_block_hash(self.GENESIS_BLOCK)
+        assert len(result) == 64
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_is_deterministic(self):
+        """El mismo bloque produce el mismo hash."""
+        r1 = calculate_concatenated_block_hash(self.GENESIS_BLOCK)
+        r2 = calculate_concatenated_block_hash(self.GENESIS_BLOCK)
+        assert r1 == r2
+
+    def test_matches_manual_sha256(self):
+        """El resultado coincide con el SHA-256 calculado manualmente."""
+        concatenated = serialize_block_fields_for_concatenation(self.GENESIS_BLOCK)
+        expected = hashlib.sha256(concatenated.encode("utf-8")).hexdigest()
+        assert calculate_concatenated_block_hash(self.GENESIS_BLOCK) == expected
+
+    def test_different_from_json_hash(self):
+        """La función de concatenación produce un hash distinto al JSON-hash para el mismo bloque."""
+        json_hash = calculate_block_hash(self.GENESIS_BLOCK)
+        concat_hash = calculate_concatenated_block_hash(self.GENESIS_BLOCK)
+        assert json_hash != concat_hash
+
+    def test_different_transactions_produce_different_hash(self):
+        """Transacciones distintas producen hashes distintos."""
+        block_a = {**self.GENESIS_BLOCK, "transactions": []}
+        block_b = self.GENESIS_BLOCK.copy()
+        assert calculate_concatenated_block_hash(block_a) != \
+               calculate_concatenated_block_hash(block_b)
+
+    def test_different_nonce_produces_different_hash(self):
+        """Un nonce distinto produce un hash distinto."""
+        block_a = {**self.GENESIS_BLOCK, "nonce": 0}
+        block_b = {**self.GENESIS_BLOCK, "nonce": 1}
+        assert calculate_concatenated_block_hash(block_a) != \
+               calculate_concatenated_block_hash(block_b)

--- a/test/test_history_service.py
+++ b/test/test_history_service.py
@@ -1,0 +1,311 @@
+"""
+Tests unitarios para src.services.history_service.get_wallet_history.
+
+Estrategia:
+- Se mockean get_transactions_collection y get_blocks_collection para
+  aislar la función de MongoDB.
+- Se verifica el enriquecimiento de estado, paginación y ordenamiento.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helper para construir mocks de colecciones
+# ---------------------------------------------------------------------------
+
+
+def make_collections(pending_txs: list[dict], blocks: list[dict]):
+    """
+    Construye mocks de las colecciones MongoDB necesarias para history_service.
+
+    Parámetros:
+        pending_txs: documentos a retornar por transactions_collection.find(query).
+        blocks: documentos a retornar por blocks_collection.find(query).
+    """
+    tx_col = MagicMock()
+    tx_col.find.return_value = iter(pending_txs)
+
+    block_col = MagicMock()
+    block_col.find.return_value = iter(blocks)
+
+    return tx_col, block_col
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetWalletHistory:
+    """Tests para get_wallet_history."""
+
+    TARGET_ADDRESS = "wallet_abc"
+
+    def _call(self, pending_txs, blocks, page=1, limit=10):
+        """Invoca get_wallet_history con las colecciones mockeadas."""
+        tx_col, block_col = make_collections(pending_txs, blocks)
+
+        with (
+            patch("src.services.history_service.get_transactions_collection", return_value=tx_col),
+            patch("src.services.history_service.get_blocks_collection", return_value=block_col),
+        ):
+            from src.services.history_service import get_wallet_history
+            return get_wallet_history(self.TARGET_ADDRESS, page=page, limit=limit)
+
+    def test_returns_empty_list_when_no_history(self):
+        """Una dirección sin actividad debe retornar lista vacía."""
+        result = self._call(pending_txs=[], blocks=[])
+        assert result == []
+
+    def test_pending_tx_from_address_appears(self):
+        """Una transacción pendiente en la que la dirección es emisora aparece en el historial."""
+        pending = [
+            {
+                "_id": "id-001",
+                "from": self.TARGET_ADDRESS,
+                "to": "other_wallet",
+                "amount": 50.0,
+                "timestamp": "2026-06-01T10:00:00Z",
+                "status": "PENDING",
+            }
+        ]
+        result = self._call(pending_txs=pending, blocks=[])
+        assert len(result) == 1
+        assert result[0]["from"] == self.TARGET_ADDRESS
+        assert result[0]["status"] == "PENDING"
+
+    def test_pending_tx_to_address_appears(self):
+        """Una transacción pendiente en la que la dirección es receptora aparece en el historial."""
+        pending = [
+            {
+                "_id": "id-002",
+                "from": "other_wallet",
+                "to": self.TARGET_ADDRESS,
+                "amount": 75.0,
+                "timestamp": "2026-06-01T11:00:00Z",
+                "status": "PENDING",
+            }
+        ]
+        result = self._call(pending_txs=pending, blocks=[])
+        assert len(result) == 1
+        assert result[0]["to"] == self.TARGET_ADDRESS
+
+    def test_confirmed_tx_in_block_appears_with_confirmed_status(self):
+        """Una transacción confirmada en un bloque aparece con status=CONFIRMED."""
+        block = {
+            "index": 3,
+            "transactions": [
+                {
+                    "id": "tx-block-001",
+                    "from": self.TARGET_ADDRESS,
+                    "to": "other_wallet",
+                    "amount": 100.0,
+                    "timestamp": "2026-06-02T10:00:00Z",
+                }
+            ],
+        }
+        result = self._call(pending_txs=[], blocks=[block])
+        assert len(result) == 1
+        assert result[0]["status"] == "CONFIRMED"
+
+    def test_confirmed_tx_has_block_index(self):
+        """Una transacción confirmada debe incluir el block_index del bloque contenedor."""
+        block = {
+            "index": 5,
+            "transactions": [
+                {
+                    "id": "tx-block-002",
+                    "from": "other_wallet",
+                    "to": self.TARGET_ADDRESS,
+                    "amount": 200.0,
+                    "timestamp": "2026-06-02T11:00:00Z",
+                }
+            ],
+        }
+        result = self._call(pending_txs=[], blocks=[block])
+        assert result[0]["block_index"] == 5
+
+    def test_tx_in_block_unrelated_to_address_is_excluded(self):
+        """Las transacciones en un bloque que no involucren la dirección no aparecen."""
+        block = {
+            "index": 1,
+            "transactions": [
+                {
+                    "id": "tx-unrelated",
+                    "from": "wallet_x",
+                    "to": "wallet_y",
+                    "amount": 999.0,
+                    "timestamp": "2026-06-01T09:00:00Z",
+                }
+            ],
+        }
+        result = self._call(pending_txs=[], blocks=[block])
+        assert result == []
+
+    def test_results_sorted_by_timestamp_descending(self):
+        """Los resultados deben estar ordenados del más reciente al más antiguo."""
+        pending = [
+            {
+                "_id": "id-early",
+                "from": self.TARGET_ADDRESS,
+                "to": "other",
+                "amount": 10.0,
+                "timestamp": "2026-06-01T08:00:00Z",
+                "status": "PENDING",
+            },
+            {
+                "_id": "id-late",
+                "from": self.TARGET_ADDRESS,
+                "to": "other",
+                "amount": 20.0,
+                "timestamp": "2026-06-03T15:00:00Z",
+                "status": "PENDING",
+            },
+        ]
+        result = self._call(pending_txs=pending, blocks=[])
+        assert result[0]["timestamp"] > result[1]["timestamp"]
+
+    def test_pagination_page1_limit2(self):
+        """page=1, limit=2 devuelve solo los 2 primeros (más recientes)."""
+        pending = [
+            {
+                "_id": f"id-{i}",
+                "from": self.TARGET_ADDRESS,
+                "to": "other",
+                "amount": float(i),
+                "timestamp": f"2026-06-0{i}T10:00:00Z",
+                "status": "PENDING",
+            }
+            for i in range(1, 5)  # 4 transacciones
+        ]
+        result = self._call(pending_txs=pending, blocks=[], page=1, limit=2)
+        assert len(result) == 2
+
+    def test_pagination_page2_limit2(self):
+        """page=2, limit=2 devuelve los 2 siguientes."""
+        pending = [
+            {
+                "_id": f"id-{i}",
+                "from": self.TARGET_ADDRESS,
+                "to": "other",
+                "amount": float(i),
+                "timestamp": f"2026-06-0{i}T10:00:00Z",
+                "status": "PENDING",
+            }
+            for i in range(1, 5)  # 4 transacciones
+        ]
+        result_p1 = self._call(pending_txs=pending, blocks=[], page=1, limit=2)
+        # Reiniciar iterador (patch se descarta al salir del contexto)
+        result_p2 = self._call(pending_txs=pending, blocks=[], page=2, limit=2)
+
+        assert len(result_p2) == 2
+        # Las páginas no deben tener elementos en común (usando timestamp como proxy)
+        timestamps_p1 = {r["timestamp"] for r in result_p1}
+        timestamps_p2 = {r["timestamp"] for r in result_p2}
+        assert timestamps_p1.isdisjoint(timestamps_p2)
+
+    def test_page_beyond_results_returns_empty(self):
+        """Una página fuera del rango de resultados retorna lista vacía."""
+        pending = [
+            {
+                "_id": "id-1",
+                "from": self.TARGET_ADDRESS,
+                "to": "other",
+                "amount": 10.0,
+                "timestamp": "2026-06-01T10:00:00Z",
+                "status": "PENDING",
+            }
+        ]
+        result = self._call(pending_txs=pending, blocks=[], page=99, limit=10)
+        assert result == []
+
+    def test_tx_without_timestamp_does_not_break_sort(self):
+        """Una transacción sin timestamp no debe romper el ordenamiento (usa '' como fallback)."""
+        pending = [
+            {
+                "_id": "id-no-ts",
+                "from": self.TARGET_ADDRESS,
+                "to": "other",
+                "amount": 5.0,
+                "status": "PENDING",
+                # sin timestamp
+            },
+            {
+                "_id": "id-with-ts",
+                "from": self.TARGET_ADDRESS,
+                "to": "other",
+                "amount": 10.0,
+                "timestamp": "2026-06-01T10:00:00Z",
+                "status": "PENDING",
+            },
+        ]
+        # No debe lanzar excepción
+        result = self._call(pending_txs=pending, blocks=[])
+        assert len(result) == 2
+
+    def test_pending_tx_without_explicit_status_defaults_to_pending(self):
+        """Una transacción del mempool sin campo status recibe status=PENDING."""
+        pending = [
+            {
+                "_id": "id-no-status",
+                "from": self.TARGET_ADDRESS,
+                "to": "other",
+                "amount": 15.0,
+                "timestamp": "2026-06-01T12:00:00Z",
+                # sin status
+            }
+        ]
+        result = self._call(pending_txs=pending, blocks=[])
+        assert result[0]["status"] == "PENDING"
+
+    def test_id_converted_to_string(self):
+        """El campo _id de MongoDB se convierte a string en el resultado."""
+        from bson import ObjectId
+
+        object_id = ObjectId()
+        pending = [
+            {
+                "_id": object_id,
+                "from": self.TARGET_ADDRESS,
+                "to": "other",
+                "amount": 5.0,
+                "timestamp": "2026-06-01T10:00:00Z",
+                "status": "PENDING",
+            }
+        ]
+        result = self._call(pending_txs=pending, blocks=[])
+        assert result[0]["_id"] == str(object_id)
+
+    def test_combined_pending_and_confirmed_transactions(self):
+        """El historial combina transacciones pendientes y confirmadas en bloques."""
+        pending = [
+            {
+                "_id": "pend-001",
+                "from": self.TARGET_ADDRESS,
+                "to": "other",
+                "amount": 10.0,
+                "timestamp": "2026-06-03T10:00:00Z",
+                "status": "PENDING",
+            }
+        ]
+        block = {
+            "index": 2,
+            "transactions": [
+                {
+                    "id": "block-tx-001",
+                    "from": "other",
+                    "to": self.TARGET_ADDRESS,
+                    "amount": 50.0,
+                    "timestamp": "2026-06-01T10:00:00Z",
+                }
+            ],
+        }
+        result = self._call(pending_txs=pending, blocks=[block])
+        assert len(result) == 2
+
+        statuses = {r["status"] for r in result}
+        assert "PENDING" in statuses
+        assert "CONFIRMED" in statuses


### PR DESCRIPTION
- test_hash_utils.py: 37 tests covering _normalize_value, serialize_block_for_hash, serialize_block_fields_for_concatenation, calculate_block_hash and calculate_concatenated_block_hash. Verifies determinism, avalanche effect and SHA-256 correctness against manual calculations.

- test_block_validation_service.py: 22 tests covering _is_iso_8601_datetime, validate_block_integrity (valid/tampered/malformed blocks) and validate_chain_integrity (empty chain, valid chain, corrupted hash, broken link). Uses real hashes computed with hash_utils, not arbitrary values.

- test_block_service.py: 24 tests covering get_last_block, save_block, create_genesis_block, get_chain (pagination skip/limit), get_block_by_index, get_block_by_hash, get_chain_stats (accumulation, edge cases) and _with_confirmed_transaction_indexes.

- test_genesis_service.py: 21 tests covering create_genesis_if_needed idempotency, DuplicateKeyError handling, RabbitMQ failure silencing, metadata update, and cryptographic correctness of build_genesis_transaction and build_genesis_block.

- test_history_service.py: 14 tests covering pending/confirmed transaction inclusion, block_index injection, descending timestamp sort, pagination and edge cases (missing timestamp, ObjectId conversion, missing status field).

Total: 125 new tests. Full suite passes at 180/180 (0 regressions).